### PR TITLE
fix: exclude peripheral batteries (Logitech HID++ mouse) on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-08-20 — Bugfix
+
+### Battery detection on Linux (wireless peripherals)
+
+- Linux battery detection no longer counts peripheral batteries (e.g. Logitech HID++ wireless mice/keyboards) as system batteries. Previously any `/sys/class/power_supply/hidpp_battery*` entry was averaged into the battery percentage/status, so a wireless mouse could make the battery read `[Discharging]`/`[Unknown]` instead of the laptop's real state. The probe now requires `type = Battery` and excludes `scope = Device` (peripherals), while real batteries (`BAT*`) are unaffected. Reported by **smashedbanan** (#179).
+
 ## 2026-08-20 — v0.7.0
 
 ### Configurable Labels and Value Formats

--- a/src/info/platform/linux/battery.rs
+++ b/src/info/platform/linux/battery.rs
@@ -12,8 +12,25 @@ const BATT_PREFIXES: [&str; 6] = [
     "ps-battery",
 ];
 
-fn is_battery_dir(name: &str) -> bool {
-    BATT_PREFIXES.iter().any(|p| name.starts_with(p))
+fn is_battery_dir(base: &std::path::Path, name: &str) -> bool {
+    if !BATT_PREFIXES.iter().any(|p| name.starts_with(p)) {
+        return false;
+    }
+    // Only a real battery counts: type must be "Battery" (excludes Mains/USB/UPS).
+    let Ok(ty) = std::fs::read_to_string(base.join("type")) else {
+        return false;
+    };
+    if ty.trim() != "Battery" {
+        return false;
+    }
+    // Exclude peripherals (e.g. Logitech HID++ mouse/keyboard): those expose
+    // scope=Device, while system batteries have no scope or scope=System.
+    if let Ok(scope) = std::fs::read_to_string(base.join("scope"))
+        && scope.trim() == "Device"
+    {
+        return false;
+    }
+    true
 }
 
 pub fn get_battery_info() -> String {
@@ -27,10 +44,10 @@ pub fn get_battery_info() -> String {
     for entry in entries.flatten() {
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        if !is_battery_dir(&name) {
+        let base = entry.path();
+        if !is_battery_dir(&base, &name) {
             continue;
         }
-        let base = entry.path();
         if let Ok(cap) = std::fs::read_to_string(base.join(BATT_CAPACITY))
             && let Ok(pct) = cap.trim().parse::<u32>()
         {


### PR DESCRIPTION
Closes #179

## Bug
Battery percentage incorrectly targets wireless mouse (#179), reported by **smashedbanan**.

## What changed
`src/info/platform/linux/battery.rs` now filters power-supply entries before counting them:

- `type` must be `Battery` (excludes `Mains`/USB/UPS sources).
- `scope = Device` is excluded (wireless peripherals like Logitech HID++), while system batteries (`BAT*`) keep working.

## Verified
- `cargo fmt --check` OK
- `cargo clippy --all-targets -- -D warnings` OK
- 141 tests passing
- Real system check: real battery (`BAT1`) still detected correctly.